### PR TITLE
test: Add asynchronous tests for MCP server connection and tool verification

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,47 @@
+import asyncio
+import pytest
+from contextlib import AsyncExitStack
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+SERVER_PATH = "/Users/mishrasunny/Documents/python-mcp/main.py"
+EXPECTED_TOOLS = [
+    "get_customer_info",
+    "get_order_details",
+    "check_inventory",
+    "get_customer_ids_by_name",
+    "get_orders_by_customer_id",
+]
+
+@pytest.mark.asyncio
+async def test_mcp_server_connection():
+    """Connect to an MCP server and verify the tools"""
+
+    exit_stack = AsyncExitStack()
+
+    server_params = StdioServerParameters(
+        command="python", args=[SERVER_PATH], env=None
+    )
+
+    stdio_transport = await exit_stack.enter_async_context(
+        stdio_client(server_params)
+    )
+    stdio, write = stdio_transport
+    session = await exit_stack.enter_async_context(
+        ClientSession(stdio, write)
+    )
+
+    await session.initialize()
+
+    response = await session.list_tools()
+    tools = response.tools
+    tool_names = [tool.name for tool in tools]
+    tool_descriptions = [tool.description for tool in tools]
+
+    print("\nYour server has the following tools:")
+    for tool_name, tool_description in zip(tool_names, tool_descriptions):
+        print(f"{tool_name}: {tool_description}")
+
+    assert sorted(EXPECTED_TOOLS) == sorted(tool_names)
+
+    await exit_stack.aclose()


### PR DESCRIPTION
Add unit tests to ensure MCP server is connected and expected tools are returned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an async pytest that connects to the MCP stdio server and asserts the exposed tools match the expected list.
> 
> - **Tests**:
>   - **Async MCP server check**: New test in `tests/test_server.py` uses `stdio_client` and `ClientSession` to initialize the server, call `list_tools`, and assert the tool names match `EXPECTED_TOOLS`.
>   - Prints tool names/descriptions for visibility and cleans up with `AsyncExitStack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbacf179565b2172cc94e78990c67c0df47ffd3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->